### PR TITLE
Renamed angular-ui-router import to @uirouter/angularjs

### DIFF
--- a/src/common/trace.ts
+++ b/src/common/trace.ts
@@ -9,19 +9,19 @@
  *
  * ### ES6
  * ```js
- * import {trace} from "ui-router-ng2"; // or "angular-ui-router"
+ * import {trace} from "@uirouter/angularjs";
  * trace.enable(1, 5); // TRANSITION and VIEWCONFIG
  * ```
  *
  * ### CJS
  * ```js
- * let trace = require("angular-ui-router").trace; // or "ui-router-ng2"
+ * let trace = require("@uirouter/angularjs").trace;
  * trace.enable("TRANSITION", "VIEWCONFIG");
  * ```
  *
  * ### Globals
  * ```js
- * let trace = window["angular-ui-router"].trace; // or "ui-router-ng2"
+ * let trace = window["@uirouter/angularjs"].trace;
  * trace.enable(); // Trace everything (very verbose)
  * ```
  *
@@ -264,7 +264,7 @@ export class Trace {
  *
  * #### Example:
  * ```js
- * import {trace} from "angular-ui-router";
+ * import {trace} from "@uirouter/angularjs";
  * trace.enable(1, 5);
  * ```
  */


### PR DESCRIPTION
Fixed the docs due to the fact that as of 1.0.0 'The npm package is renamed from angular-ui-router to @uirouter/angularjs'. https://github.com/angular-ui/ui-router/blob/master/CHANGELOG.md#notice-the-npm-package-is-renamed-from-angular-ui-router-to-uirouterangularjs